### PR TITLE
ci: Fix phinx update issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ node_modules
 package-lock.json
 package.json
 .phpunit.result.cache
+.vscode
 logs
 old

--- a/src/Model/Behavior/DatFieldBehavior.php
+++ b/src/Model/Behavior/DatFieldBehavior.php
@@ -129,8 +129,8 @@ class DatFieldBehavior extends Behavior
     public function afterMarshal(
         EventInterface $event,
         EntityInterface $entity,
-        \ArrayObject $data,
-        \ArrayObject $options
+        ArrayObject $data,
+        ArrayObject $options
     ): void {
         if (!$this->_datFieldsEnabled) {
             return;
@@ -147,7 +147,7 @@ class DatFieldBehavior extends Behavior
      * @param \ArrayObject $options Options
      * @return \Cake\ORM\Query
      */
-    public function beforeFind(EventInterface $event, Query $query, \ArrayObject $options): Query
+    public function beforeFind(EventInterface $event, Query $query, ArrayObject $options): Query
     {
         if (!empty($options['jsonTypeMap'])) {
             $this->_setTransientJsonTypes($options['jsonTypeMap'] ?? null);
@@ -166,7 +166,7 @@ class DatFieldBehavior extends Behavior
      * @param \ArrayObject $options Options
      * @return void
      */
-    public function beforeSave(EventInterface $event, EntityInterface $entity, \ArrayObject $options): void
+    public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
         $this->_setTransientJsonTypes($options['jsonTypeMap'] ?? null);
     }

--- a/tests/Model/Table/AgentsTable.php
+++ b/tests/Model/Table/AgentsTable.php
@@ -26,5 +26,12 @@ class AgentsTable extends DatfieldBehaviorTable
           'className' => ClientsTable::class,
           'foreignKey' => 'attributes->agent_id',
         ]);
+
+        $this->datFieldHasMany('Specialclients', [
+          'className' => ClientsTable::class,
+          'foreignKey' => 'attributes->agent_id',
+          'propertyName' => 'clients',
+          'finder' => 'specials',
+        ]);
     }
 }

--- a/tests/Model/Table/ClientsTable.php
+++ b/tests/Model/Table/ClientsTable.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lqdt\OrmJson\Test\Model\Table;
 
+use Cake\ORM\Query;
 use Lqdt\OrmJson\Test\Model\Entity\Client;
 
 /**
@@ -30,5 +31,10 @@ class ClientsTable extends DatfieldBehaviorTable
           'foreignKey' => 'attributes->client_id',
           'dependent' => true,
         ]);
+    }
+
+    public function findSpecials(Query $q): Query
+    {
+        return $q->where(['attributes->level' => 2]);
     }
 }

--- a/tests/TestCase/Database/Driver/TranslateDatFieldTest.php
+++ b/tests/TestCase/Database/Driver/TranslateDatFieldTest.php
@@ -19,6 +19,11 @@ class TranslateDatFieldTest extends TestCase
             "JSON_EXTRACT(data, '$.p')",
           ],
           [
+            ['data->p', 'data->p2'],
+            false,
+            ["JSON_EXTRACT(data, '$.p')", "JSON_EXTRACT(data, '$.p2')"],
+          ],
+          [
             'data->[*]',
             false,
             "JSON_EXTRACT(data, '$[*]')",
@@ -42,12 +47,19 @@ class TranslateDatFieldTest extends TestCase
     }
 
     /** @dataProvider translateDatFieldMysqlData */
-    public function testTranslateDatFieldMysql(string $datfield, bool $unquote, string $expected): void
+    public function testTranslateDatFieldMysql($datfield, bool $unquote, $expected): void
     {
         /** @var \Lqdt\OrmJson\Database\DatFieldDriverInterface $driver */
         $driver = $this->connection->getDriver();
         /** @var \Lqdt\OrmJson\Database\Expression\DatFieldExpression $result */
         $result = $driver->translateDatField($datfield, $unquote);
-        $this->assertEquals($expected, $result->sql(new ValueBinder()));
+        $this->assertEquals(
+            $expected,
+            is_array($result) ?
+              array_map(function ($e) {
+                  return $e->sql(new ValueBinder());
+              }, $result) :
+              $result->sql(new ValueBinder())
+        );
     }
 }

--- a/tests/TestCase/Database/Driver/TranslateDatFieldTest.php
+++ b/tests/TestCase/Database/Driver/TranslateDatFieldTest.php
@@ -46,7 +46,12 @@ class TranslateDatFieldTest extends TestCase
         ];
     }
 
-    /** @dataProvider translateDatFieldMysqlData */
+    /**
+     * @dataProvider translateDatFieldMysqlData
+     * @param string|array<string> $datfield Datfield
+     * @param bool $unquote Unquote
+     * @param string|array<string> $expected Expected result
+     */
     public function testTranslateDatFieldMysql($datfield, bool $unquote, $expected): void
     {
         /** @var \Lqdt\OrmJson\Database\DatFieldDriverInterface $driver */

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -136,6 +136,19 @@ class HasManyTest extends TestCase
         }
     }
 
+    public function testFinderContain(): void
+    {
+        $agents = $this->Agents->find()->contain('Specialclients')->toArray();
+
+        $this->assertNotEmpty($agents);
+
+        foreach ($agents as $agent) {
+            foreach ($agent->clients as $client) {
+                $this->assertEquals(2, $client->get('attributes->level'));
+            }
+        }
+    }
+
     public function testMatching(): void
     {
         $agents = $this->Agents->find()->matching('Clients', function ($q) {

--- a/tests/config/Migrations/1_DatabaseSetup.php
+++ b/tests/config/Migrations/1_DatabaseSetup.php
@@ -16,38 +16,38 @@ class DatabaseSetup extends AbstractMigration
     public function change()
     {
         $table = $this->table('objects', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('attributes', 'json', ['null' => true]);
         $table->addColumn('at2', 'json', ['null' => true]);
         $table->create();
 
         $table = $this->table('agents', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('attributes', 'json', ['null' => true]);
         $table->create();
 
         $table = $this->table('clients', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('attributes', 'json', ['null' => true]);
         $table->create();
 
         $table = $this->table('contacts', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('attributes', 'json', ['null' => true]);
         $table->create();
 
         $table = $this->table('agents_clients', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('attributes', 'json', ['null' => true]);
         $table->create();
 
         $table = $this->table('drivers', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('name', 'string', ['null' => false]);
         $table->create();
 
         $table = $this->table('vehicles', ['id' => false, 'primary_key' => ['id']]);
-        $table->addColumn('id', 'uuid');
+        $table->addColumn('id', 'uuid', ['null' => false]);
         $table->addColumn('geocode_id', 'uuid', ['null' => false]);
         $table->create();
 


### PR DESCRIPTION
Last phinx update was breaking migration due to file name starting only by 0 and `not null` for primary key not implicit anymore.